### PR TITLE
LogonProofError.__str__ will now return strings

### DIFF
--- a/tclib/shared/exceptions.py
+++ b/tclib/shared/exceptions.py
@@ -21,7 +21,7 @@ class LogonProofError(Exception):
     def __init__(self, value):
         self.value = value
     def __str__(self):
-        return self.value
+        return str(self.value)
 
 
 class CODENotImplementedError(Exception):


### PR DESCRIPTION
LogonProofError.**str** will now return strings in the event on numerical error types

Previously, a numerical error would throw a subsequent exception,
preventing the error from being seen:

  File
"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
logging/**init**.py", line 851, in emit
    msg = self.format(record)
  File
"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
logging/**init**.py", line 724, in format
    return fmt.format(record)
  File
"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
logging/**init**.py", line 464, in format
    record.message = record.getMessage()
  File
"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
logging/**init**.py", line 324, in getMessage
    msg = str(self.msg)
TypeError: **str** returned non-string (type int)

Now, the error type will be correctly logged

4
Traceback (most recent call last):
  File “/…/tclib/tclib/realm/realm.py", line 71, in run
    self._handlers[cmd]()
  File “/…/tclib/tclib/realm/realm.py", line 301, in _handle_logon_proof
    raise LogonProofError(err)
LogonProofError: 4
